### PR TITLE
M-M-M-MULTI-TRY

### DIFF
--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -23,8 +23,9 @@ namespace GitHub.Internals
         /// <summary>
         /// Defines the operation to try.
         /// </summary>
+        /// <param name="name"></param>
         /// <param name="candidate">The delegate to execute.</param>
-        void Try(Func<T> candidate);
+        void Try(string name, Func<T> candidate);
 
         /// <summary>
         /// Defines the operation to actually use.
@@ -58,8 +59,9 @@ namespace GitHub.Internals
         /// <summary>
         /// Defines the operation to try.
         /// </summary>
+        /// <param name="name"></param>
         /// <param name="candidate">The delegate to execute.</param>
-        void Try(Func<Task<T>> candidate);
+        void Try(string name, Func<Task<T>> candidate);
 
         /// <summary>
         /// Defines the operation to actually use.

--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -23,6 +23,12 @@ namespace GitHub.Internals
         /// <summary>
         /// Defines the operation to try.
         /// </summary>
+        /// <param name="candidate">The delegate to execute.</param>
+        void Try(Func<T> candidate);
+
+        /// <summary>
+        /// Defines the operation to try.
+        /// </summary>
         /// <param name="name"></param>
         /// <param name="candidate">The delegate to execute.</param>
         void Try(string name, Func<T> candidate);
@@ -55,6 +61,12 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="check">The delegate to evaluate.</param>
         void RunIf(Func<Task<bool>> block);
+
+        /// <summary>
+        /// Defines the operation to try.
+        /// </summary>
+        /// <param name="candidate">The delegate to execute.</param>
+        void Try(Func<Task<T>> candidate);
 
         /// <summary>
         /// Defines the operation to try.

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -12,8 +12,7 @@ namespace GitHub.Internals
 
         string _name;
         Func<Task<T>> _control;
-
-        //TODO: Do we need a thread safe dictionary?
+        
         readonly Dictionary<string, Func<Task<T>>> _candidates;
         Func<T, T, bool> _comparison = DefaultComparison;
         Func<Task> _beforeRun;

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -40,7 +40,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(CandidateExperimentName))
             {
-                throw new InvalidOperationException("You have already added a default try, name this one something different");
+                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>> overload");
             }
             _candidates.Add(CandidateExperimentName, candidate);
         }
@@ -49,7 +49,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(CandidateExperimentName))
             {
-                throw new InvalidOperationException("You have already added a default try, name this one something different");
+                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>> overload");
             }
             _candidates.Add(CandidateExperimentName, () => Task.FromResult(candidate()));
         }
@@ -58,7 +58,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(name))
             {
-                throw new InvalidOperationException($"You already have a candidate named {name}, name this one something different");
+                throw new InvalidOperationException($"You already have a candidate named {name}. Provide a different name for this test.");
             }
             _candidates.Add(name, candidate);
         }
@@ -67,7 +67,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(name))
             {
-                throw new InvalidOperationException($"You already have a candidate named {name}, name this one something different");
+                throw new InvalidOperationException($"You already have a candidate named {name}. Provide a different name for this test.");
             }
             _candidates.Add(name, () => Task.FromResult(candidate()));
         }

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -40,7 +40,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(CandidateExperimentName))
             {
-                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>> overload");
+                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>>) overload");
             }
             _candidates.Add(CandidateExperimentName, candidate);
         }
@@ -49,7 +49,7 @@ namespace GitHub.Internals
         {
             if (_candidates.ContainsKey(CandidateExperimentName))
             {
-                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>> overload");
+                throw new InvalidOperationException("You have already added a default try. Give this candidate a new name with the Try(string, Func<Task<T>>) overload");
             }
             _candidates.Add(CandidateExperimentName, () => Task.FromResult(candidate()));
         }

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -11,7 +11,6 @@ namespace GitHub.Internals
     /// <typeparam name="T">The return type of the experiment</typeparam>
     internal class ExperimentInstance<T>
     {
-        internal const string CandidateExperimentName = "candidate";
         internal const string ControlExperimentName = "control";
 
         readonly string _name;

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -22,24 +22,26 @@ namespace GitHub.Internals
         
         static Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
 
-        public ExperimentInstance(string name, Func<Task<T>> control, Func<Task<T>> candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf)
+        public ExperimentInstance(string name, Func<Task<T>> control, Dictionary<string, Func<Task<T>>> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf)
             : this(name,
                   new NamedBehavior(ControlExperimentName, control),
-                  new NamedBehavior(CandidateExperimentName, candidate),
+                  candidates.Select(c => new NamedBehavior(c.Key, c.Value)),
                   comparator,
                   beforeRun,
                   runIf)
         {
         }
 
-        internal ExperimentInstance(string name, NamedBehavior control, NamedBehavior candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf)
+        internal ExperimentInstance(string name, NamedBehavior control, IEnumerable<NamedBehavior> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf)
         {
             _name = name;
+
             _behaviors = new List<NamedBehavior>
             {
                 control,
-                candidate
             };
+            _behaviors.AddRange(candidates);
+
             _comparator = comparator;
             _beforeRun = beforeRun;
             _runIf = runIf;

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -27,7 +27,7 @@ public class TheScientistClass
             {
                 experiment.RunIf(mock.RunIf);
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(expectedResult, result);
@@ -50,7 +50,7 @@ public class TheScientistClass
                 Scientist.Science<int>(experimentName, experiment =>
                 {
                     experiment.Use(mock.Control);
-                    experiment.Try(mock.Candidate);
+                    experiment.Try("candidate", mock.Candidate);
                 });
             });
 
@@ -72,7 +72,7 @@ public class TheScientistClass
             var result = Scientist.Science<int>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(42, result);
@@ -92,7 +92,7 @@ public class TheScientistClass
             var result = await Scientist.ScienceAsync<int>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(42, result);
@@ -108,7 +108,7 @@ public class TheScientistClass
             var result = Scientist.Science<object>(experimentName, experiment =>
             {
                 experiment.Use(() => null);
-                experiment.Try(() => null);
+                experiment.Try("candidate", () => null);
             });
 
             Assert.Null(result);
@@ -136,7 +136,7 @@ public class TheScientistClass
             var result = Scientist.Science<int>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(42, result);
@@ -160,7 +160,7 @@ public class TheScientistClass
             var result = Scientist.Science<int>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(42, result);
@@ -184,7 +184,7 @@ public class TheScientistClass
             {
                 experiment.Compare((a, b) => a.Count == b.Count && a.Name == b.Name);
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(10, result.Count);
@@ -206,7 +206,7 @@ public class TheScientistClass
             {
                 experiment.Compare((a, b) => a.Count == b.Count && a.Name == b.Name);
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(10, result.Count);
@@ -227,7 +227,7 @@ public class TheScientistClass
             var result = Scientist.Science<ComplexResult>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(10, result.Count);
@@ -248,7 +248,7 @@ public class TheScientistClass
             var result = Scientist.Science<ComplexResult>(experimentName, experiment =>
             {
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(10, result.Count);
@@ -270,7 +270,7 @@ public class TheScientistClass
             {
                 experiment.BeforeRun(mock.BeforeRun);
                 experiment.Use(mock.Control);
-                experiment.Try(mock.Candidate);
+                experiment.Try("candidate", mock.Candidate);
             });
 
             Assert.Equal(42, result);

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -276,5 +276,57 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().BeforeRun();
         }
+
+        [Fact]
+        public void AllTrysAreRun()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+            var mockTwo = Substitute.For<IControlCandidate<int>>();
+            mockTwo.Candidate().Returns(42);
+            var mockThree = Substitute.For<IControlCandidate<int>>();
+            mockThree.Candidate().Returns(42);
+
+            const string experimentName = nameof(AllTrysAreRun);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try("candidate one", mock.Candidate);
+                experiment.Try("candidate two", mockTwo.Candidate);
+                experiment.Try("candidate three", mockThree.Candidate);
+            });
+
+            Assert.Equal(42, result);
+            mock.Received().Candidate();
+            mockTwo.Received().Candidate();
+            mockThree.Received().Candidate();
+        }
+
+        [Fact]
+        public void SingleCandidateCausesMismatch()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+            var mockTwo = Substitute.For<IControlCandidate<int>>();
+            mockTwo.Candidate().Returns(42);
+            var mockThree = Substitute.For<IControlCandidate<int>>();
+            mockThree.Candidate().Returns(0);
+
+            const string experimentName = nameof(AllTrysAreRun);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try("candidate one", mock.Candidate);
+                experiment.Try("candidate two", mockTwo.Candidate);
+                experiment.Try("candidate three", mockThree.Candidate);
+            });
+
+            Assert.Equal(42, result);
+            Assert.False(TestHelper.Results<int>().First().Matched);
+        }
     }
 }


### PR DESCRIPTION
Allow user to call `Try` multiple times. The doesn't have to set a name for the first try, but any additional calls will require using the overload with a name specified.