### PR TITLE
Use NugetVersion instead of SemVer

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -71,7 +71,7 @@ let UpdateProjectJson projectJson =
     
     let tempReleaseNotes = toLines releaseNotes.Notes
     RegexReplaceInFileWithEncoding "\"releaseNotes\": \"\"," ("\"releaseNotes\": \"" + tempReleaseNotes +  "\",") Encoding.UTF8 fullJsonPath
-    RegexReplaceInFileWithEncoding versionRegex ("${1}" + (releaseNotes.SemVer.ToString()) + "${3}") Encoding.UTF8 fullJsonPath
+    RegexReplaceInFileWithEncoding versionRegex ("${1}" + (releaseNotes.NugetVersion) + "${3}") Encoding.UTF8 fullJsonPath
 
 let RestoreProjectJson projectJson =
     let fullJsonPath = (__SOURCE_DIRECTORY__ + projectJson)


### PR DESCRIPTION
I noticed that all nuget packages created in appveyor are missing the Number part of the prelease, i.e. instead of the current version of `1.0.0-alpha4` the package is being created as `1.0.0-alpha`. Originally we were using the `ReleaseNotesHelper.SemVer` prop in FAKE, but the output of that is missing the prerelease number. I *think* this is a bug in FAKE and I just opened an issue on that to see if we can get it resolved.

For now we can use the `NugetVersion` which includes the number. 