### PR TITLE
Ignore

### DIFF
--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -41,7 +41,7 @@ namespace GitHub.Internals
         /// Defines the check to run to determine if mismatches should be ignored.
         /// </summary>
         /// <param name="block">The delegate to execute</param>
-        void Ignore(Func<bool> block);
+        void Ignore(Func<T, T, bool> block);
     }
 
     /// <summary>
@@ -82,6 +82,6 @@ namespace GitHub.Internals
         /// Defines the check to run to determine if mismatches should be ignored.
         /// </summary>
         /// <param name="block">The delegate to execute</param>
-        void Ignore(Func<Task<bool>> block);
+        void Ignore(Func<T, T, Task<bool>> block);
     }
 }

--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -36,6 +36,12 @@ namespace GitHub.Internals
         /// Defines a custom func used to compare results.
         /// </summary>
         void Compare(Func<T, T, bool> comparison);
+
+        /// <summary>
+        /// Defines the check to run to determine if mismatches should be ignored.
+        /// </summary>
+        /// <param name="block">The delegate to execute</param>
+        void Ignore(Func<bool> block);
     }
 
     /// <summary>
@@ -71,5 +77,11 @@ namespace GitHub.Internals
         /// Defines a func used to compare results.
         /// </summary>
         void Compare(Func<T, T, bool> comparison);
+
+        /// <summary>
+        /// Defines the check to run to determine if mismatches should be ignored.
+        /// </summary>
+        /// <param name="block">The delegate to execute</param>
+        void Ignore(Func<Task<bool>> block);
     }
 }

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GitHub.Internals
@@ -13,6 +14,7 @@ namespace GitHub.Internals
         Func<T, T, bool> _comparison = DefaultComparison;
         Func<Task> _beforeRun;
         Func<Task<bool>> _runIf = _alwaysRun;
+        HashSet<Func<Task<bool>>> _ignores { get; set; } = new HashSet<Func<Task<bool>>>();
 
         public Experiment(string name)
         {
@@ -38,8 +40,14 @@ namespace GitHub.Internals
         public void Try(Func<T> candidate) =>
             _candidate = () => Task.FromResult(candidate());
 
+        public void Ignore(Func<bool> block) => 
+            _ignores.Add(() => Task.FromResult(block()));
+
+        public void Ignore(Func<Task<bool>> block) => 
+            _ignores.Add(block);
+
         internal ExperimentInstance<T> Build() =>
-            new ExperimentInstance<T>(_name, _control, _candidate, _comparison, _beforeRun, _runIf);
+            new ExperimentInstance<T>(_name, _control, _candidate, _comparison, _beforeRun, _runIf, _ignores);
 
         public void Compare(Func<T, T, bool> comparison)
         {

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -14,7 +14,7 @@ namespace GitHub.Internals
         Func<T, T, bool> _comparison = DefaultComparison;
         Func<Task> _beforeRun;
         Func<Task<bool>> _runIf = _alwaysRun;
-        readonly List<Func<Task<bool>>> _ignores = new List<Func<Task<bool>>>();
+        readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
 
         public Experiment(string name)
         {
@@ -40,10 +40,10 @@ namespace GitHub.Internals
         public void Try(Func<T> candidate) =>
             _candidate = () => Task.FromResult(candidate());
 
-        public void Ignore(Func<bool> block) => 
-            _ignores.Add(() => Task.FromResult(block()));
+        public void Ignore(Func<T, T, bool> block) => 
+            _ignores.Add((con, can) => Task.FromResult(block(con, can)));
 
-        public void Ignore(Func<Task<bool>> block) => 
+        public void Ignore(Func<T, T, Task<bool>> block) => 
             _ignores.Add(block);
 
         internal ExperimentInstance<T> Build() =>

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -27,6 +27,7 @@ namespace GitHub.Internals
 
         public void RunIf(Func<Task<bool>> block) =>
             _runIf = block;
+
         public void RunIf(Func<bool> block) =>
             _runIf = () => Task.FromResult(block());
 

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -14,7 +14,7 @@ namespace GitHub.Internals
         Func<T, T, bool> _comparison = DefaultComparison;
         Func<Task> _beforeRun;
         Func<Task<bool>> _runIf = _alwaysRun;
-        HashSet<Func<Task<bool>>> _ignores { get; set; } = new HashSet<Func<Task<bool>>>();
+        readonly List<Func<Task<bool>>> _ignores = new List<Func<Task<bool>>>();
 
         public Experiment(string name)
         {

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -77,7 +77,7 @@ namespace GitHub.Internals
 
             var controlObservation = observations.FirstOrDefault(o => o.Name == ControlExperimentName);
             
-            var result = new Result<T>(this, observations, controlObservation, Comparator);
+            var result = new Result<T>(this, observations, controlObservation);
 
             // TODO: Make this Fire and forget so we don't have to wait for this
             // to complete before we return a result

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -14,16 +14,16 @@ namespace GitHub.Internals
         internal const string CandidateExperimentName = "candidate";
         internal const string ControlExperimentName = "control";
 
-        readonly string _name;
-        readonly List<NamedBehavior> _behaviors;
-        readonly Func<T, T, bool> _comparator;
-        readonly Func<Task> _beforeRun;
-        readonly Func<Task<bool>> _runIf;
-        readonly IEnumerable<Func<Task<bool>>> _ignores;
+        internal readonly string Name;
+        internal readonly List<NamedBehavior> Behaviors;
+        internal readonly Func<T, T, bool> Comparator;
+        internal readonly Func<Task> BeforeRun;
+        internal readonly Func<Task<bool>> RunIf;
+        internal readonly IEnumerable<Func<T, T, Task<bool>>> Ignores;
         
         static Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
 
-        public ExperimentInstance(string name, Func<Task<T>> control, Func<Task<T>> candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<Task<bool>>> ignores)
+        public ExperimentInstance(string name, Func<Task<T>> control, Func<Task<T>> candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores)
             : this(name,
                   new NamedBehavior(ControlExperimentName, control),
                   new NamedBehavior(CandidateExperimentName, candidate),
@@ -34,56 +34,50 @@ namespace GitHub.Internals
         {
         }
 
-        internal ExperimentInstance(string name, NamedBehavior control, NamedBehavior candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<Task<bool>>> ignores)
+        internal ExperimentInstance(string name, NamedBehavior control, NamedBehavior candidate, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores)
         {
-            _name = name;
-            _behaviors = new List<NamedBehavior>
+            Name = name;
+            Behaviors = new List<NamedBehavior>
             {
                 control,
                 candidate
             };
-            _comparator = comparator;
-            _beforeRun = beforeRun;
-            _runIf = runIf;
-            _ignores = ignores;
+            Comparator = comparator;
+            BeforeRun = beforeRun;
+            RunIf = runIf;
+            Ignores = ignores;
         }
 
         public async Task<T> Run()
         {
             // Determine if experiments should be run.
-            if (!await _runIf())
+            if (!await RunIf())
             {
                 // Run the control behavior.
-                return await _behaviors[0].Behavior();
+                return await Behaviors[0].Behavior();
             }
 
-            if (_beforeRun != null)
+            if (BeforeRun != null)
             {
-                await _beforeRun();
+                await BeforeRun();
             }
 
             // Randomize ordering...
             NamedBehavior[] orderedBehaviors;
             lock (_random)
             {
-                orderedBehaviors = _behaviors.OrderBy(b => _random.Next()).ToArray();
+                orderedBehaviors = Behaviors.OrderBy(b => _random.Next()).ToArray();
             }
 
             var observations = new List<Observation<T>>();
             foreach (var behavior in orderedBehaviors)
             {
-                observations.Add(await Observation<T>.New(behavior.Name, behavior.Behavior, _comparator));
+                observations.Add(await Observation<T>.New(behavior.Name, behavior.Behavior, Comparator));
             }
 
             var controlObservation = observations.FirstOrDefault(o => o.Name == ControlExperimentName);
-
-            var ignored = false;
-            foreach (var ignore in _ignores)
-            {
-                ignored = ignored || await ignore();
-            }
-
-            var result = new Result<T>(_name, observations, controlObservation, _comparator, ignored);
+            
+            var result = new Result<T>(this, observations, controlObservation, Comparator);
 
             // TODO: Make this Fire and forget so we don't have to wait for this
             // to complete before we return a result
@@ -91,6 +85,19 @@ namespace GitHub.Internals
 
             if (controlObservation.Thrown) throw controlObservation.Exception;
             return controlObservation.Value;
+        }
+
+        public async Task<bool> IgnoreMismatchedObservation(Observation<T> control, Observation<T> candidate)
+        {
+            if (!Ignores.Any())
+            {
+                return false;
+            }
+
+            //TODO: Does this really need to be async? We could run sync and return on first true
+            var results = await Task.WhenAll(Ignores.Select(i => i(control.Value, candidate.Value)));
+
+            return results.Any(i => i);
         }
         
         internal class NamedBehavior

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GitHub.Internals;
 
@@ -7,14 +6,14 @@ namespace GitHub
 {
     public class Result<T>
     {
-        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control, Func<T, T, bool> comparator)
+        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control)
         {
             Candidates = observations.Where(o => o != control).ToList();
             Control = control;
             ExperimentName = experiment.Name;
             Observations = observations.ToList();
 
-            MismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, comparator)).ToList();
+            MismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, experiment.Comparator)).ToList();
 
             IgnoredObservations = MismatchedObservations.Where(m => experiment.IgnoreMismatchedObservation(control, m).Result).ToList();
         }

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -6,16 +6,16 @@ namespace GitHub
 {
     public class Result<T>
     {
-        public Result(string experimentName, IEnumerable<Observation<T>> observations, Observation<T> control, Func<T, T, bool> comparator)
+        public Result(string experimentName, IEnumerable<Observation<T>> observations, Observation<T> control, Func<T, T, bool> comparator, bool ignored)
         {
             Candidates = observations.Where(o => o != control).ToList();
             Control = control;
             ExperimentName = experimentName;
             Observations = observations.ToList();
 
-            MismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, comparator)).ToList();
-            
-            // TODO Implement ignored observations.
+            MismatchedObservations = Candidates.Where(o => !ignored && !o.EquivalentTo(Control, comparator)).ToList();
+
+            IgnoredObservations = Candidates.Except(MismatchedObservations).ToList();
         }
 
         /// <summary>
@@ -52,5 +52,10 @@ namespace GitHub
         /// Gets all of the observations.
         /// </summary>
         public IReadOnlyList<Observation<T>> Observations { get; }
+
+        /// <summary>
+        /// Gets all of the mismatched observations whos values where ignored.
+        /// </summary>
+        public IReadOnlyList<Observation<T>> IgnoredObservations { get; }
     }
 }

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -13,9 +13,11 @@ namespace GitHub
             ExperimentName = experiment.Name;
             Observations = observations.ToList();
 
-            MismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, experiment.Comparator)).ToList();
+            var mismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, experiment.Comparator)).ToList();
 
-            IgnoredObservations = MismatchedObservations.Where(m => experiment.IgnoreMismatchedObservation(control, m).Result).ToList();
+            IgnoredObservations = mismatchedObservations.Where(m => experiment.IgnoreMismatchedObservation(control, m).Result).ToList();
+
+            MismatchedObservations = mismatchedObservations.Except(IgnoredObservations).ToList();
         }
 
         /// <summary>

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -363,7 +363,7 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
-            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
@@ -387,7 +387,7 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
-            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
@@ -409,7 +409,7 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
-            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -276,5 +276,120 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().BeforeRun();
         }
+
+        [Fact]
+        public void ExperimentIgnoredIfIgnoreTrue()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentIgnoredIfIgnoreTrue);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore(() => true);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.True(experimentResult.IgnoredObservations.Any());
+            Assert.True(experimentResult.Matched);
+        }
+
+        [Fact]
+        public void ExperimentRunsIfIgnoreFalse()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentRunsIfIgnoreFalse);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore(() => false);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.False(experimentResult.IgnoredObservations.Any());
+            Assert.False(experimentResult.Matched);
+        }
+
+        [Fact]
+        public void ExperimentRunsIfMultipleIgnoresAllFalse()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentRunsIfMultipleIgnoresAllFalse);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore(() => false);
+                experiment.Ignore(() => false);
+                experiment.Ignore(() => false);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.False(experimentResult.IgnoredObservations.Any());
+            Assert.False(experimentResult.Matched);
+        }
+
+        [Fact]
+        public void ExperimentIgnoredIfMultipleIgnoresAllTrue()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentIgnoredIfMultipleIgnoresAllTrue);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore(() => true);
+                experiment.Ignore(() => true);
+                experiment.Ignore(() => true);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.False(experimentResult.MismatchedObservations.Any());
+            Assert.True(experimentResult.IgnoredObservations.Any());
+            Assert.True(experimentResult.Matched);
+        }
+
+        [Fact]
+        public void ExperimentIgnoredIfMultipleIgnoresOnlyOneTrue()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentIgnoredIfMultipleIgnoresOnlyOneTrue);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore(() => true);
+                experiment.Ignore(() => false);
+                experiment.Ignore(() => false);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.False(experimentResult.MismatchedObservations.Any());
+            Assert.True(experimentResult.IgnoredObservations.Any());
+            Assert.True(experimentResult.Matched);
+        }
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -391,5 +391,27 @@ public class TheScientistClass
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
+
+        [Fact]
+        public void ExperimentIgnoredWithComplexIgnoreFunc()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(-1);
+            const string experimentName = nameof(ExperimentIgnoredWithComplexIgnoreFunc);
+
+            var result = Scientist.Science<int>(experimentName, experiment =>
+            {
+                experiment.Use(mock.Control);
+                experiment.Try(mock.Candidate);
+                experiment.Ignore((control, candidate) => control > 0 && candidate == -1);
+            });
+
+            Assert.Equal(42, result);
+            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Assert.True(experimentResult.MismatchedObservations.Any());
+            Assert.True(experimentResult.IgnoredObservations.Any());
+            Assert.True(experimentResult.Matched);
+        }
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -289,7 +289,7 @@ public class TheScientistClass
             {
                 experiment.Use(mock.Control);
                 experiment.Try(mock.Candidate);
-                experiment.Ignore(() => true);
+                experiment.Ignore((control, candidate) => true);
             });
 
             Assert.Equal(42, result);
@@ -310,7 +310,7 @@ public class TheScientistClass
             {
                 experiment.Use(mock.Control);
                 experiment.Try(mock.Candidate);
-                experiment.Ignore(() => false);
+                experiment.Ignore((control, candidate) => false);
             });
 
             Assert.Equal(42, result);
@@ -332,9 +332,9 @@ public class TheScientistClass
             {
                 experiment.Use(mock.Control);
                 experiment.Try(mock.Candidate);
-                experiment.Ignore(() => false);
-                experiment.Ignore(() => false);
-                experiment.Ignore(() => false);
+                experiment.Ignore((control, candidate) => false);
+                experiment.Ignore((control, candidate) => false);
+                experiment.Ignore((control, candidate) => false);
             });
 
             Assert.Equal(42, result);
@@ -356,14 +356,14 @@ public class TheScientistClass
             {
                 experiment.Use(mock.Control);
                 experiment.Try(mock.Candidate);
-                experiment.Ignore(() => true);
-                experiment.Ignore(() => true);
-                experiment.Ignore(() => true);
+                experiment.Ignore((control, candidate) => true);
+                experiment.Ignore((control, candidate) => true);
+                experiment.Ignore((control, candidate) => true);
             });
 
             Assert.Equal(42, result);
             var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
-            Assert.False(experimentResult.MismatchedObservations.Any());
+            Assert.True(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
@@ -380,14 +380,14 @@ public class TheScientistClass
             {
                 experiment.Use(mock.Control);
                 experiment.Try(mock.Candidate);
-                experiment.Ignore(() => true);
-                experiment.Ignore(() => false);
-                experiment.Ignore(() => false);
+                experiment.Ignore((control, candidate) => true);
+                experiment.Ignore((control, candidate) => false);
+                experiment.Ignore((control, candidate) => false);
             });
 
             Assert.Equal(42, result);
             var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
-            Assert.False(experimentResult.MismatchedObservations.Any());
+            Assert.True(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }


### PR DESCRIPTION
Allow ignoring of results. User can enter 1 or more checks to ignore a mismatch. If a mismatch is ignored:
- The result of the experiment is `Matched`
- `MismatchedObservations` is empty
- `IgnoredObservations` is populated