### PR TITLE
Experiment context

### DIFF
--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -56,14 +56,6 @@ namespace GitHub.Internals
         /// <param name="key">The name of the context</param>
         /// <param name="data">The context data</param>
         void AddContext(string key, object data);
-
-        /// <summary>
-        /// Defines data to publish with results. 
-        /// </summary>
-        /// <param name="key">The name of the context</param>
-        /// <param name="data">The context data</param>
-        /// <returns ></returns>
-        bool TryAddContext(string key, dynamic data);
     }
 
     /// <summary>
@@ -119,12 +111,5 @@ namespace GitHub.Internals
         /// <param name="key">The name of the context</param>
         /// <param name="data">The context data</param>
         void AddContext(string key, object data);
-
-        /// <summary>
-        /// Defines data to publish with results. 
-        /// </summary>
-        /// <param name="key">The name of the context</param>
-        /// <param name="data">The context data</param>
-        bool TryAddContext(string key, dynamic data);
     }
 }

--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -55,7 +55,15 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="key">The name of the context</param>
         /// <param name="data">The context data</param>
-        void Context(string key, object data);
+        void AddContext(string key, object data);
+
+        /// <summary>
+        /// Defines data to publish with results. 
+        /// </summary>
+        /// <param name="key">The name of the context</param>
+        /// <param name="data">The context data</param>
+        /// <returns ></returns>
+        bool TryAddContext(string key, dynamic data);
     }
 
     /// <summary>
@@ -110,6 +118,13 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="key">The name of the context</param>
         /// <param name="data">The context data</param>
-        void Context(string key, object data);
+        void AddContext(string key, object data);
+
+        /// <summary>
+        /// Defines data to publish with results. 
+        /// </summary>
+        /// <param name="key">The name of the context</param>
+        /// <param name="data">The context data</param>
+        bool TryAddContext(string key, dynamic data);
     }
 }

--- a/src/Scientist/IExperiment.cs
+++ b/src/Scientist/IExperiment.cs
@@ -49,6 +49,13 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="block">The delegate to execute</param>
         void Ignore(Func<T, T, bool> block);
+
+        /// <summary>
+        /// Defines data to publish with results.
+        /// </summary>
+        /// <param name="key">The name of the context</param>
+        /// <param name="data">The context data</param>
+        void Context(string key, object data);
     }
 
     /// <summary>
@@ -97,5 +104,12 @@ namespace GitHub.Internals
         /// </summary>
         /// <param name="block">The delegate to execute</param>
         void Ignore(Func<T, T, Task<bool>> block);
+
+        /// <summary>
+        /// Defines data to publish with results.
+        /// </summary>
+        /// <param name="key">The name of the context</param>
+        /// <param name="data">The context data</param>
+        void Context(string key, object data);
     }
 }

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -18,6 +18,7 @@ namespace GitHub.Internals
         Func<Task> _beforeRun;
         Func<Task<bool>> _runIf = _alwaysRun;
         readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
+        readonly Dictionary<string, object> _contexts = new Dictionary<string, object>();
 
         public Experiment(string name)
         {
@@ -79,8 +80,11 @@ namespace GitHub.Internals
         public void Ignore(Func<T, T, Task<bool>> block) => 
             _ignores.Add(block);
 
+        public void Context(string key, object data) =>
+            _contexts.Add(key, data);
+
         internal ExperimentInstance<T> Build() =>
-            new ExperimentInstance<T>(_name, _control, _candidates, _comparison, _beforeRun, _runIf, _ignores);
+            new ExperimentInstance<T>(_name, _control, _candidates, _comparison, _beforeRun, _runIf, _ignores, _contexts);
 
         public void Compare(Func<T, T, bool> comparison)
         {

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -89,17 +89,6 @@ namespace GitHub.Internals
             _contexts.Add(key, data);
         }
 
-        public bool TryAddContext(string key, dynamic data)
-        {
-            if (_contexts.ContainsKey(key))
-            {
-                return false;
-            }
-
-            _contexts.Add(key, data);
-            return true;
-        }
-
         internal ExperimentInstance<T> Build() =>
             new ExperimentInstance<T>(_name, _control, _candidates, _comparison, _beforeRun, _runIf, _ignores, _contexts);
 

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -18,7 +18,7 @@ namespace GitHub.Internals
         Func<Task> _beforeRun;
         Func<Task<bool>> _runIf = _alwaysRun;
         readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
-        readonly Dictionary<string, object> _contexts = new Dictionary<string, object>();
+        readonly Dictionary<string, dynamic> _contexts = new Dictionary<string, dynamic>();
 
         public Experiment(string name)
         {
@@ -80,7 +80,7 @@ namespace GitHub.Internals
         public void Ignore(Func<T, T, Task<bool>> block) => 
             _ignores.Add(block);
 
-        public void Context(string key, object data) =>
+        public void Context(string key, dynamic data) =>
             _contexts.Add(key, data);
 
         internal ExperimentInstance<T> Build() =>

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -19,11 +19,11 @@ namespace GitHub.Internals
         internal readonly Func<Task> BeforeRun;
         internal readonly Func<Task<bool>> RunIf;
         internal readonly IEnumerable<Func<T, T, Task<bool>>> Ignores;
-        internal readonly Dictionary<string, object> Contexts;
+        internal readonly Dictionary<string, dynamic> Contexts;
         
         static Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
         
-        public ExperimentInstance(string name, Func<Task<T>> control, Dictionary<string, Func<Task<T>>> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, object> contexts)
+        public ExperimentInstance(string name, Func<Task<T>> control, Dictionary<string, Func<Task<T>>> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, dynamic> contexts)
             : this(name,
                   new NamedBehavior(ControlExperimentName, control),
                   candidates.Select(c => new NamedBehavior(c.Key, c.Value)),
@@ -35,7 +35,7 @@ namespace GitHub.Internals
         {
         }
         
-        internal ExperimentInstance(string name, NamedBehavior control, IEnumerable<NamedBehavior> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, object> contexts)
+        internal ExperimentInstance(string name, NamedBehavior control, IEnumerable<NamedBehavior> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, dynamic> contexts)
         {
             Name = name;
 

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -19,21 +19,23 @@ namespace GitHub.Internals
         internal readonly Func<Task> BeforeRun;
         internal readonly Func<Task<bool>> RunIf;
         internal readonly IEnumerable<Func<T, T, Task<bool>>> Ignores;
+        internal readonly Dictionary<string, object> Contexts;
         
         static Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
         
-        public ExperimentInstance(string name, Func<Task<T>> control, Dictionary<string, Func<Task<T>>> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores)
+        public ExperimentInstance(string name, Func<Task<T>> control, Dictionary<string, Func<Task<T>>> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, object> contexts)
             : this(name,
                   new NamedBehavior(ControlExperimentName, control),
                   candidates.Select(c => new NamedBehavior(c.Key, c.Value)),
                   comparator,
                   beforeRun,
                   runIf,
-                  ignores)
+                  ignores,
+                  contexts)
         {
         }
         
-        internal ExperimentInstance(string name, NamedBehavior control, IEnumerable<NamedBehavior> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores)
+        internal ExperimentInstance(string name, NamedBehavior control, IEnumerable<NamedBehavior> candidates, Func<T, T, bool> comparator, Func<Task> beforeRun, Func<Task<bool>> runIf, IEnumerable<Func<T, T, Task<bool>>> ignores, Dictionary<string, object> contexts)
         {
             Name = name;
 
@@ -47,6 +49,7 @@ namespace GitHub.Internals
             BeforeRun = beforeRun;
             RunIf = runIf;
             Ignores = ignores;
+            Contexts = contexts;
         }
 
         public async Task<T> Run()
@@ -78,7 +81,7 @@ namespace GitHub.Internals
 
             var controlObservation = observations.FirstOrDefault(o => o.Name == ControlExperimentName);
             
-            var result = new Result<T>(this, observations, controlObservation);
+            var result = new Result<T>(this, observations, controlObservation, Contexts);
 
             // TODO: Make this Fire and forget so we don't have to wait for this
             // to complete before we return a result

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -6,7 +6,7 @@ namespace GitHub
 {
     public class Result<T>
     {
-        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control, Dictionary<string, object> contexts)
+        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control, Dictionary<string, dynamic> contexts)
         {
             Candidates = observations.Where(o => o != control).ToList();
             Control = control;
@@ -64,6 +64,6 @@ namespace GitHub
         /// <summary>
         /// Gets the context data supplied to the experiment.
         /// </summary>
-        public IReadOnlyDictionary<string, object> Contexts { get; }
+        public IReadOnlyDictionary<string, dynamic> Contexts { get; }
     }
 }

--- a/src/Scientist/Result.cs
+++ b/src/Scientist/Result.cs
@@ -6,12 +6,13 @@ namespace GitHub
 {
     public class Result<T>
     {
-        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control)
+        internal Result(ExperimentInstance<T> experiment, IEnumerable<Observation<T>> observations, Observation<T> control, Dictionary<string, object> contexts)
         {
             Candidates = observations.Where(o => o != control).ToList();
             Control = control;
             ExperimentName = experiment.Name;
             Observations = observations.ToList();
+            Contexts = contexts;
 
             var mismatchedObservations = Candidates.Where(o => !o.EquivalentTo(Control, experiment.Comparator)).ToList();
 
@@ -59,5 +60,10 @@ namespace GitHub
         /// Gets all of the mismatched observations whos values where ignored.
         /// </summary>
         public IReadOnlyList<Observation<T>> IgnoredObservations { get; }
+
+        /// <summary>
+        /// Gets the context data supplied to the experiment.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> Contexts { get; }
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -539,7 +539,7 @@ public class TheScientistClass
             {
                 e.Use(mock.Control);
                 e.Try(mock.Candidate);
-                e.Context("test", "data");
+                e.AddContext("test", "data");
             });
 
             var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
@@ -565,9 +565,9 @@ public class TheScientistClass
             {
                 e.Use(mock.Control);
                 e.Try(mock.Candidate);
-                e.Context("test", "data");
-                e.Context("test2", "data2");
-                e.Context("test3", "data3");
+                e.AddContext("test", "data");
+                e.AddContext("test2", "data2");
+                e.AddContext("test3", "data3");
             });
 
             var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
@@ -603,7 +603,7 @@ public class TheScientistClass
             {
                 e.Use(mock.Control);
                 e.Try(mock.Candidate);
-                e.Context("test", new {Id = 1, Name = "name", Date = testTime});
+                e.AddContext("test", new {Id = 1, Name = "name", Date = testTime});
             });
 
             var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -660,28 +660,5 @@ public class TheScientistClass
                 });
             });
         }
-        
-        [Fact]
-        public void TryAddContextReturnsFalseIfDuplicateKeyAdded()
-        {
-            var mock = Substitute.For<IControlCandidate<int>>();
-            mock.Control().Returns(42);
-            mock.Candidate().Returns(42);
-
-            const string experimentName = nameof(TryAddContextReturnsFalseIfDuplicateKeyAdded);
-
-            bool tryAddResult = false;
-
-            var result = Scientist.Science<int>(experimentName, e =>
-            {
-                e.Use(mock.Control);
-                e.Try(mock.Candidate);
-                e.TryAddContext("test", "data");
-                tryAddResult = e.TryAddContext("test", "data");
-            });
-
-            Assert.Equal(42, result);
-            Assert.False(tryAddResult);
-        }
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -527,13 +527,13 @@ public class TheScientistClass
         }
 
         [Fact]
-        public void ContextsAreIncludedWithPublish()
+        public void SingleContextIncludedWithPublish()
         {
             var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
             mock.Candidate().Returns(42);
 
-            const string experimentName = nameof(ContextsAreIncludedWithPublish);
+            const string experimentName = nameof(SingleContextIncludedWithPublish);
 
             var result = Scientist.Science<int>(experimentName, e =>
             {
@@ -549,13 +549,37 @@ public class TheScientistClass
         }
 
         [Fact]
+        public void MultipleContextsIncludedWithPublish()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(MultipleContextsIncludedWithPublish);
+
+            var result = Scientist.Science<int>(experimentName, e =>
+            {
+                e.Use(mock.Control);
+                e.Try(mock.Candidate);
+                e.Context("test", "data");
+                e.Context("test2", "data2");
+                e.Context("test3", "data3");
+            });
+
+            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+
+            Assert.Equal(42, result);
+            Assert.Equal(3, publishResults.Contexts.Count);
+        }
+
+        [Fact]
         public void ContextEmptyIfNoContextSupplied()
         {
             var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
             mock.Candidate().Returns(42);
 
-            const string experimentName = nameof(ContextsAreIncludedWithPublish);
+            const string experimentName = nameof(ContextEmptyIfNoContextSupplied);
 
             var result = Scientist.Science<int>(experimentName, e =>
             {

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -525,5 +525,48 @@ public class TheScientistClass
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
+
+        [Fact]
+        public void ContextsAreIncludedWithPublish()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(ContextsAreIncludedWithPublish);
+
+            var result = Scientist.Science<int>(experimentName, e =>
+            {
+                e.Use(mock.Control);
+                e.Try(mock.Candidate);
+                e.Context("test", "data");
+            });
+
+            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+
+            Assert.Equal(42, result);
+            Assert.True(publishResults.Contexts.Any());
+        }
+
+        [Fact]
+        public void ContextEmptyIfNoContextSupplied()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(ContextsAreIncludedWithPublish);
+
+            var result = Scientist.Science<int>(experimentName, e =>
+            {
+                e.Use(mock.Control);
+                e.Try(mock.Candidate);
+            });
+
+            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+
+            Assert.Equal(42, result);
+            Assert.False(publishResults.Contexts.Any());
+        }
     }
 }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -546,6 +546,10 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             Assert.True(publishResults.Contexts.Any());
+
+            var context = publishResults.Contexts.First();
+            Assert.Equal("test", context.Key);
+            Assert.Equal("data", context.Value);
         }
 
         [Fact]
@@ -570,6 +574,18 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             Assert.Equal(3, publishResults.Contexts.Count);
+
+            var context = publishResults.Contexts.First();
+            Assert.Equal("test", context.Key);
+            Assert.Equal("data", context.Value);
+
+            context = publishResults.Contexts.Skip(1).First();
+            Assert.Equal("test2", context.Key);
+            Assert.Equal("data2", context.Value);
+
+            context = publishResults.Contexts.Skip(2).First();
+            Assert.Equal("test3", context.Key);
+            Assert.Equal("data3", context.Value);
         }
 
         [Fact]

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -545,7 +545,7 @@ public class TheScientistClass
             var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
 
             Assert.Equal(42, result);
-            Assert.True(publishResults.Contexts.Any());
+            Assert.Equal(1, publishResults.Contexts.Count);
 
             var context = publishResults.Contexts.First();
             Assert.Equal("test", context.Key);
@@ -586,6 +586,36 @@ public class TheScientistClass
             context = publishResults.Contexts.Skip(2).First();
             Assert.Equal("test3", context.Key);
             Assert.Equal("data3", context.Value);
+        }
+
+        [Fact]
+        public void ContextReturnsComplexObjectInPublish()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(ContextReturnsComplexObjectInPublish);
+
+            var testTime = DateTime.UtcNow;
+
+            var result = Scientist.Science<int>(experimentName, e =>
+            {
+                e.Use(mock.Control);
+                e.Try(mock.Candidate);
+                e.Context("test", new {Id = 1, Name = "name", Date = testTime});
+            });
+
+            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+
+            Assert.Equal(42, result);
+            Assert.Equal(1, publishResults.Contexts.Count);
+
+            var context = publishResults.Contexts.First();
+            Assert.Equal("test", context.Key);
+            Assert.Equal(1, context.Value.Id);
+            Assert.Equal("name", context.Value.Name);
+            Assert.Equal(testTime, context.Value.Date);
         }
 
         [Fact]

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 public class TheScientistClass
 {
+    //TODO: Clean up this class
     public class TheScienceMethod
     {
         [Fact]
@@ -637,6 +638,50 @@ public class TheScientistClass
 
             Assert.Equal(42, result);
             Assert.False(publishResults.Contexts.Any());
+        }
+        
+        [Fact]
+        public void AddContextThrowsIfDuplicateKeyAdded()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(AddContextThrowsIfDuplicateKeyAdded);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                Scientist.Science<int>(experimentName, e =>
+                {
+                    e.Use(mock.Control);
+                    e.Try(mock.Candidate);
+                    e.AddContext("test", "data");
+                    e.AddContext("test", "data");
+                });
+            });
+        }
+        
+        [Fact]
+        public void TryAddContextReturnsFalseIfDuplicateKeyAdded()
+        {
+            var mock = Substitute.For<IControlCandidate<int>>();
+            mock.Control().Returns(42);
+            mock.Candidate().Returns(42);
+
+            const string experimentName = nameof(TryAddContextReturnsFalseIfDuplicateKeyAdded);
+
+            bool tryAddResult = false;
+
+            var result = Scientist.Science<int>(experimentName, e =>
+            {
+                e.Use(mock.Control);
+                e.Try(mock.Candidate);
+                e.TryAddContext("test", "data");
+                tryAddResult = e.TryAddContext("test", "data");
+            });
+
+            Assert.Equal(42, result);
+            Assert.False(tryAddResult);
         }
     }
 }


### PR DESCRIPTION
Add context to an experiment. Takes a string and an object, adds to a dictionary and supplies a readonly dictionary with the result for publishing. 