### PR TITLE
Add support for running tasks concurrently

### DIFF
--- a/src/Scientist/Extensions/LinqExtensionMethods.cs
+++ b/src/Scientist/Extensions/LinqExtensionMethods.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitHub.Internals.Extensions
+{
+    internal static class LinqExtensionMethods
+    {
+        /// <summary>
+        /// Break a list of items into chunks of a specific size
+        /// </summary>
+        internal static IEnumerable<IEnumerable<T>> Chunk<T>(this IEnumerable<T> source, int chunksize)
+        {
+            if (chunksize <= 0)
+                throw new ArgumentException("Argument must be greater than 0", "chunkSize");
+
+            while (source.Any())
+            {
+                yield return source.Take(chunksize);
+                source = source.Skip(chunksize);
+            }
+        }
+    }
+}

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -13,6 +13,8 @@ namespace GitHub.Internals
             = (operation, exception) => { throw exception; };
 
         private string _name;
+        private int _concurrentTasks;
+
         private Func<Task<T>> _control;
 
         private readonly Dictionary<string, Func<Task<T>>> _candidates;
@@ -23,9 +25,13 @@ namespace GitHub.Internals
         private readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
         private readonly Dictionary<string, dynamic> _contexts = new Dictionary<string, dynamic>();
 
-        public Experiment(string name)
+        public Experiment(string name, int concurrentTasks)
         {
+            if (concurrentTasks <= 0)
+                throw new ArgumentException("Argument must be greater than 0", "concurrentTasks");
+
             _name = name;
+            _concurrentTasks = concurrentTasks;
             _candidates = new Dictionary<string, Func<Task<T>>>();
         }
 
@@ -103,6 +109,7 @@ namespace GitHub.Internals
                 BeforeRun = _beforeRun,
                 Candidates = _candidates,
                 Comparator = _comparison,
+                ConcurrentTasks = _concurrentTasks,
                 Contexts = _contexts,
                 Control = _control,
                 Ignores = _ignores,

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -82,7 +82,7 @@ namespace GitHub.Internals
                 var tasks = behaviors.Select(b =>
                 {
                     return Observation<T, TClean>.New(
-	                    b.Name,
+                        b.Name,
                         b.Behavior,
                         Comparator,
                         Thrown,

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -14,6 +14,7 @@ namespace GitHub.Internals
         internal const string ControlExperimentName = "control";
 
         internal readonly string Name;
+        internal readonly int ConcurrentTasks;
         internal readonly List<NamedBehavior> Behaviors;
         internal readonly Func<T, T, bool> Comparator;
         internal readonly Func<Task> BeforeRun;
@@ -38,6 +39,7 @@ namespace GitHub.Internals
 
             BeforeRun = settings.BeforeRun;
             Comparator = settings.Comparator;
+            ConcurrentTasks = settings.ConcurrentTasks;
             Contexts = settings.Contexts;
             RunIf = settings.RunIf;
             Ignores = settings.Ignores;

--- a/src/Scientist/Internals/ExperimentSettings.cs
+++ b/src/Scientist/Internals/ExperimentSettings.cs
@@ -18,6 +18,7 @@ namespace GitHub.Internals
         public Func<Task<T>> Control { get; set; }
         public IEnumerable<Func<T, T, Task<bool>>> Ignores { get; set; }
         public string Name { get; set; }
+        public int ConcurrentTasks { get; set; }
         public Func<Task<bool>> RunIf { get; set; }
         public bool ThrowOnMismatches { get; set; }
         public Action<Operation, Exception> Thrown { get; set; }

--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -28,7 +28,7 @@ namespace GitHub
         {
             // TODO: Maybe we could automatically generate the name if none is provided using the calling method name. We'd have to 
             // make sure we don't inline this method though.
-            var experimentBuilder = new Experiment<T>(name);
+            var experimentBuilder = new Experiment<T>(name, 1);
             
             experiment(experimentBuilder);
 
@@ -44,7 +44,20 @@ namespace GitHub
         /// <returns>The value of the experiment's control function.</returns>
         public static Task<T> ScienceAsync<T>(string name, Action<IExperimentAsync<T>> experiment)
         {
-            var experimentBuilder = new Experiment<T>(name);
+            return ScienceAsync<T>(name, 1, experiment);
+        }
+
+        /// <summary>
+        /// Conduct an asynchronous experiment
+        /// </summary>
+        /// <typeparam name="T">The return type of the experiment</typeparam>
+        /// <param name="name">Name of the experiment</param>
+        /// <param name="concurrentTasks">Number of tasks to run concurrently</param>
+        /// <param name="experiment">Experiment callback used to configure the experiment</param>
+        /// <returns>The value of the experiment's control function.</returns>
+        public static Task<T> ScienceAsync<T>(string name, int concurrentTasks, Action<IExperimentAsync<T>> experiment)
+        {
+            var experimentBuilder = new Experiment<T>(name, concurrentTasks);
             
             experiment(experimentBuilder);
 

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -825,7 +825,7 @@ public class TheScientistClass
             }
 
 
-            // Now assert btach execution times
+            // Now assert batch execution times
             for (int batch = 1; batch <= batchTimes.Count; batch++)
             {
                 // Ensure start time within batch are within tolerance

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -34,7 +34,7 @@ public class TheScientistClass
 
             mock.DidNotReceive().Candidate();
             mock.Received().Control();
-            Assert.False(TestHelper.Results<int>().Any(m => m.ExperimentName == experimentName));
+            Assert.False(TestHelper.Results<int>(experimentName).Any());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ public class TheScientistClass
             Assert.IsType<InvalidOperationException>(baseException);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(TestHelper.Results<int>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.True(TestHelper.Results<int>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(TestHelper.Results<int>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.True(TestHelper.Results<int>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -98,7 +98,7 @@ public class TheScientistClass
             Assert.Equal(42, result);
             await mock.Received().Control();
             await mock.Received().Candidate();
-            Assert.False(TestHelper.Results<int>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.False(TestHelper.Results<int>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -112,7 +112,7 @@ public class TheScientistClass
             });
 
             Assert.Null(result);
-            Assert.True(TestHelper.Results<object>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.True(TestHelper.Results<object>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ public class TheScientistClass
             mock.Received().Control();
             mock.Received().Candidate();
 
-            Result<int> observedResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Result<int> observedResult = TestHelper.Results<int>(experimentName).First();
             Assert.True(observedResult.Matched);
             Assert.True(observedResult.Control.Duration.Ticks > 0);
             Assert.True(observedResult.Observations.All(o => o.Duration.Ticks > 0));
@@ -166,7 +166,7 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().Control();
             mock.Received().Candidate();
-            Result<int> observedResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            Result<int> observedResult = TestHelper.Results<int>(experimentName).First();
             Assert.False(observedResult.Matched);
             Assert.True(observedResult.Control.Duration.Ticks > 0);
             Assert.True(observedResult.Observations.All(o => o.Duration.Ticks > 0));
@@ -191,7 +191,7 @@ public class TheScientistClass
             Assert.Equal("Tester", result.Name);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(TestHelper.Results<ComplexResult>().First().Matched);
+            Assert.True(TestHelper.Results<ComplexResult>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -213,7 +213,7 @@ public class TheScientistClass
             Assert.Equal("Tester", result.Name);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.False(TestHelper.Results<ComplexResult>().First().Matched);
+            Assert.False(TestHelper.Results<ComplexResult>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ public class TheScientistClass
             Assert.Equal("Tester", result.Name);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(TestHelper.Results<ComplexResult>().First().Matched);
+            Assert.True(TestHelper.Results<ComplexResult>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -255,7 +255,7 @@ public class TheScientistClass
             Assert.Equal("Tester", result.Name);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.False(TestHelper.Results<ComplexResult>().First().Matched);
+            Assert.False(TestHelper.Results<ComplexResult>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -326,7 +326,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            Assert.False(TestHelper.Results<int>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.False(TestHelper.Results<int>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -386,7 +386,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            Assert.True(TestHelper.Results<int>().First(m => m.ExperimentName == experimentName).Matched);
+            Assert.True(TestHelper.Results<int>(experimentName).First().Matched);
         }
 
         [Fact]
@@ -405,7 +405,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
         }
@@ -426,7 +426,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.True(experimentResult.MismatchedObservations.Any());
             Assert.False(experimentResult.IgnoredObservations.Any());
             Assert.False(experimentResult.Matched);
@@ -450,7 +450,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.True(experimentResult.MismatchedObservations.Any());
             Assert.False(experimentResult.IgnoredObservations.Any());
             Assert.False(experimentResult.Matched);
@@ -474,7 +474,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
@@ -498,7 +498,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
@@ -520,7 +520,7 @@ public class TheScientistClass
             });
 
             Assert.Equal(42, result);
-            var experimentResult = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var experimentResult = TestHelper.Results<int>(experimentName).First();
             Assert.False(experimentResult.MismatchedObservations.Any());
             Assert.True(experimentResult.IgnoredObservations.Any());
             Assert.True(experimentResult.Matched);
@@ -542,7 +542,7 @@ public class TheScientistClass
                 e.AddContext("test", "data");
             });
 
-            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var publishResults = TestHelper.Results<int>(experimentName).First();
 
             Assert.Equal(42, result);
             Assert.Equal(1, publishResults.Contexts.Count);
@@ -570,7 +570,7 @@ public class TheScientistClass
                 e.AddContext("test3", "data3");
             });
 
-            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var publishResults = TestHelper.Results<int>(experimentName).First();
 
             Assert.Equal(42, result);
             Assert.Equal(3, publishResults.Contexts.Count);
@@ -606,7 +606,7 @@ public class TheScientistClass
                 e.AddContext("test", new {Id = 1, Name = "name", Date = testTime});
             });
 
-            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var publishResults = TestHelper.Results<int>(experimentName).First();
 
             Assert.Equal(42, result);
             Assert.Equal(1, publishResults.Contexts.Count);
@@ -633,7 +633,7 @@ public class TheScientistClass
                 e.Try(mock.Candidate);
             });
 
-            var publishResults = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var publishResults = TestHelper.Results<int>(experimentName).First();
 
             Assert.Equal(42, result);
             Assert.False(publishResults.Contexts.Any());
@@ -683,7 +683,7 @@ public class TheScientistClass
             mock.Received().Control();
             mock.Received().Candidate();
 
-            var result = TestHelper.Results<int>().First(m => m.ExperimentName == experimentName);
+            var result = TestHelper.Results<int>(experimentName).First();
             var mismatchException = (MismatchException<int>)baseException;
             Assert.Equal(experimentName, mismatchException.Name);
             Assert.Same(result, mismatchException.Result);

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -813,7 +813,7 @@ public class TheScientistClass
             });
 
             // Run the experiment
-            const string experimentName = nameof(ThrowsArgumentExceptionWhenConcurrentTasksInvalid);
+            string experimentName = nameof(RunsTasksConcurrently) + concurrentTasks;
             await Scientist.ScienceAsync<int>(experimentName, concurrentTasks, experiment =>
             {
                 // Add our control and experiments

--- a/test/Scientist.Test/TestHelper.cs
+++ b/test/Scientist.Test/TestHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GitHub;
 using GitHub.Internals;
 using NSubstitute;
@@ -7,7 +8,7 @@ using NSubstitute.Core;
 
 public static class TestHelper
 {
-    public static IEnumerable<Result<T>> Results<T>() => ((InMemoryResultPublisher)Scientist.ResultPublisher).Results<T>();
+    public static IEnumerable<Result<T>> Results<T>(string experimentName) => ((InMemoryResultPublisher)Scientist.ResultPublisher).Results<T>().Where(x => x.ExperimentName == experimentName);
 
     public static ConfiguredCall Throws<T>(this T value, Exception e) => value.Returns(_ => { throw e; });
 }


### PR DESCRIPTION
Fixes #62

As discussed in #62 the `ScienceAsync` method can now specify concurrency settings (how many tasks to run at once).  Internally I am splitting the orderedBehaviors into smaller sublists (of `ConcurrentTasks` size), running the tasks in the sublist in parallel and collecting the observations.

I also added a test that asserts the tasks are in fact running concurrently by running 4 tasks with concurrent settings of 1,2 and 4 and ensuring the time taken to execute the `ScienceAsync` is as expected (with a small amount of headroom for plumbing code).

Possible enhancements could be an option to run ALL tasks concurrently rather than specifying the number.  Also I could easily add support for the task concurrency on the regular `Science` method too, rather than just `ScienceAsync`?


As an aside I also found issues with running the existing tests due to some of them not specifying their `experimentName` in the `TestHelper.Results()` call.  I tweaked the `TestHelper` to force a `experimentName` to be passed in rather than relying on the calling code to use a lambda, which seems better than needing to remember :grinning: 

Even with that I do sometimes find tests will still fail randomly, I suspect the static ``Scientist.ResultPublisher` is at fault and tests executing simultaneously are sometimes tripping over eachother on this?