### PR TITLE
Added new tests for experiment without Try

### DIFF
--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -821,7 +821,8 @@ public class TheScientistClass
                 experiment.Use(() => 42);
             });
 
-            Assert.False(TestHelper.Results<int>().Any(m => m.ExperimentName == experimentName));
+            Assert.False(TestHelper.Results<int>().Any(m => m.ExperimentName == experimentName),
+                "When an experiment without a candidate is run, no results should be published.");
         }
     }
 }


### PR DESCRIPTION
Added new test to ensure that experiment returns correctly even without any candidate. Also added tests to verify that the Clean, RunIf and Enabled delegates are not run and no publish is done if there are no candidates.